### PR TITLE
Take the intrinsic size of the image when getting the image data

### DIFF
--- a/src/utils/getImageData.ts
+++ b/src/utils/getImageData.ts
@@ -4,11 +4,12 @@ const getImageData = (input: HTMLImageElement | HTMLCanvasElement) => {
       .getContext('2d')!
       .getImageData(0, 0, input.width, input.height);
   }
+  const inputImage = (input as HTMLImageElement);
   const c = document.createElement('canvas');
-  c.width = input.width;
-  c.height = input.height;
+  c.width = inputImage.naturalWidth;
+  c.height = inputImage.naturalHeight;
   const ctx = c.getContext('2d')!;
   ctx.drawImage(input, 0, 0);
-  return ctx.getImageData(0, 0, input.width, input.height);
+  return ctx.getImageData(0, 0, inputImage.naturalWidth, inputImage.naturalHeight);
 };
 export default getImageData;


### PR DESCRIPTION
Explanation: When the image element is resized (e.g. when using a smaller viewport on mobile) the image is scaled automatically. Taking the element width and height in the getImageData function will lose pixels as the image could be scaled down.